### PR TITLE
Add GitHub Issue Templates for Bug Reports and Feature Requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug Report
+about: Create a report to help us improve by describing a bug.
+title: "[BUG]"
+labels: bug
+assignees: ''
+---
+
+## Describe the bug
+A clear and concise description of what the bug is.
+
+## To Reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '...'
+3. See error
+
+## Expected behavior
+What you expected to happen.
+
+## Screenshots
+If applicable, add screenshots to help explain your problem.
+
+## Environment (please complete the following):
+- OS: [e.g., Windows, macOS, Linux]
+- Browser: [e.g., Chrome, Safari]
+- Version: [e.g., 1.0.0]
+
+## Additional context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement.
+title: "[FEATURE]"
+labels: enhancement
+assignees: ''
+---
+
+## Is your feature request related to a problem? Please describe.
+A clear and concise description of what the problem is. Ex: I'm always frustrated when [...]
+
+## Describe the solution you'd like
+A clear and concise description of what you want to happen.
+
+## Additional context
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
## What was changed:
- Created `.github/ISSUE_TEMPLATE/` directory structure
- Added `bug_report.md` template with comprehensive sections for bug reporting
- Added `feature_request.md` template with structured sections for feature proposals
- Both templates include proper YAML frontmatter with appropriate labels and titles

## Impact:
This enhancement significantly improves the issue reporting process by:
- Providing clear guidance to contributors on required information
- Ensuring consistent formatting across all issue reports

## How to test:
1. Navigate to the repository's "Issues" tab
2. Click "New Issue" button
3. Verify GitHub presents template chooser with "Bug Report" and "Feature Request" options
4. Select each template type and confirm proper markdown content loads
5. Ensure templates include appropriate labels and prefilled titles

## Additional context:
This addresses the issue raised about lacking standardized issue templates, which was causing inconsistent and incomplete reports. The templates follow GitHub best practices and include all essential sections mentioned in the original issue. These templates will help maintain an organized issue tracking system and lower the barrier for newcomers to contribute effectively.

Fixes #6 

## Note:
email : nishchyapsingh@gmail.com
