### PR TITLE
Revert SESSION_SECRET -> SECRET and restore listing image upload field

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Create a `.env` file in the root directory with the following variables:
 NODE_ENV=development
 PORT=3000
 ATLASDB_URL=your_mongodb_atlas_connection_string
-SESSION_SECRET=your_session_secret_key
+SECRET=your_session_secret_key
 CLOUDINARY_CLOUD_NAME=your_cloudinary_cloud_name
 CLOUDINARY_KEY=your_cloudinary_api_key
 CLOUDINARY_SECRET=your_cloudinary_api_secret

--- a/app.js
+++ b/app.js
@@ -74,7 +74,7 @@ if (dbUrl) {
 }
 
 const sessionOptions = {
-  secret: process.env.SESSION_SECRET,
+  secret: process.env.SECRET,
   resave: false,
   saveUninitialized: true,
   cookie: {

--- a/routes/listing.js
+++ b/routes/listing.js
@@ -40,7 +40,7 @@ router
   .get(wrapAsync(listingController.index))
   .post(
     isLoggedIn,
-    upload.single("listing[image]"),
+    upload.single("listing[image][url]"),
     validateListing,
     wrapAsync(listingController.addNew)
   );
@@ -66,7 +66,7 @@ router.put(
   "/:id",
   isLoggedIn,
   isOwner,
-  upload.single("listing[image]"),
+  upload.single("listing[image][url]"),
   validateListing,
   wrapAsync(listingController.update)
 );

--- a/views/listings/create.ejs
+++ b/views/listings/create.ejs
@@ -41,7 +41,7 @@
               </label>
               <input 
                 id="image"
-                name="listing[image]" 
+                name="listing[image][url]" 
                 type="file" 
                 class="form-control"
                 accept="image/*"

--- a/views/listings/edit.ejs
+++ b/views/listings/edit.ejs
@@ -24,7 +24,7 @@
       <br />
       <div class="mb-3">
         <label for="image" class="form-label">Upload New Image </label>
-        <input name="listing[image]" type="file" class="form-control" />
+        <input name="listing[image][url]" type="file" class="form-control" />
       </div>
       <br />
       <div class="mb-3">


### PR DESCRIPTION
What: Revert env var name to SECRET; restore form input name and multer field so image uploads save to listing.image.url again.
Why: Preserve existing deployments and fix broken image uploads introduced by the merged PR.
